### PR TITLE
Updates to let code build with DEBUG=TRUE and gnu compiler

### DIFF
--- a/cellular_automata_global.F90
+++ b/cellular_automata_global.F90
@@ -48,7 +48,7 @@ integer,save :: isdnx,iednx,jsdnx,jednx
 integer,save :: iscnx,iecnx,jscnx,jecnx
 integer :: nxncells, nyncells
 integer(8) :: count, count_rate, count_max, count_trunc,nx_full
-integer(8) :: iscale = 10000000000
+integer(8) :: iscale = 10000000000_8
 integer, allocatable :: iini_g(:,:,:),ilives_g(:,:)
 real(kind=kind_dbl_prec), allocatable :: field_out(:,:,:), field_smooth(:,:)
 real(kind=kind_dbl_prec), allocatable :: CA(:,:),CA1(:,:),CA2(:,:),CA3(:,:),CAprime(:,:)
@@ -160,7 +160,7 @@ k_in=1
        else
           ! don't rely on compiler to truncate integer(8) to integer(4) on
           ! overflow, do wrap around explicitly.
-          count4 = mod(((iseed_ca+7)*mytile)*(i1+nx_full*(j1-1))+ 2147483648, 4294967296) - 2147483648
+          count4 = int(mod(int(((iseed_ca+7)*mytile)*(i1+nx_full*(j1-1)), 8) + 2147483648_8, 4294967296_8) - 2147483648_8)
        endif
        ct=1
        do nf=1,nca

--- a/cellular_automata_sgs.F90
+++ b/cellular_automata_sgs.F90
@@ -63,7 +63,7 @@ integer :: blocksz,levs
 integer :: ncells,nlives
 integer, save :: initialize_ca
 integer(8) :: count, count_rate, count_max, count_trunc,nx_full
-integer(8) :: iscale = 10000000000
+integer(8) :: iscale = 10000000000_8
 integer, allocatable :: iini(:,:,:),ilives_in(:,:,:),ca_plumes(:,:),io_layout(:)
 real(kind=kind_phys), allocatable :: ssti(:,:),lsmski(:,:),lakei(:,:)
 real(kind=kind_phys), allocatable :: CA(:,:),condition(:,:),conditiongrid(:,:)
@@ -257,7 +257,7 @@ if (.not. restart) then
             else
                ! don't rely on compiler to truncate integer(8) to integer(4) on
                ! overflow, do wrap around explicitly.
-               count4 = mod((iseed_ca+mytile)*(i1+nx_full*(j1-1))+ 2147483648, 4294967296) - 2147483648
+               count4 = int(mod(int((iseed_ca+mytile)*(i1+nx_full*(j1-1)), 8) + 2147483648_8, 4294967296_8) - 2147483648_8)
             endif
             ct=1
             do nf=1,nca

--- a/mersenne_twister.F90
+++ b/mersenne_twister.F90
@@ -175,7 +175,7 @@
         integer,parameter:: n=624
         integer,parameter:: m=397
         integer,parameter:: mata=-1727483681     !< constant vector a
-        integer,parameter:: umask=-2147483648    !< most significant w-r bits
+        integer,parameter:: umask=-2147483647-1  !< most significant w-r bits
         integer,parameter:: lmask =2147483647    !< least significant r bits
         integer,parameter:: tmaskb=-1658038656   !< tempering parameter
         integer,parameter:: tmaskc=-272236544    !< tempering parameter

--- a/stochy_patterngenerator.F90
+++ b/stochy_patterngenerator.F90
@@ -63,7 +63,7 @@ module stochy_patterngenerator_mod
    integer(8), intent(inout) :: iseed(npatterns)
    integer m,j,l,n,nm,nn,np,indev1,indev2,indod1,indod2
    integer(8) count, count_rate, count_max, count_trunc
-   integer(8) :: iscale = 10000000000
+   integer(8) :: iscale = 10000000000_8
    integer count4, ierr
    logical :: bn_local ! berner normalization
 !   integer  member_id
@@ -171,7 +171,7 @@ module stochy_patterngenerator_mod
            ! don't rely on compiler to truncate integer(8) to integer(4) on
            ! overflow, do wrap around explicitly.
            !count4 = mod(iseed(np) + member_id + 2147483648, 4294967296) - 2147483648
-           count4 = mod(iseed(np) + 2147483648, 4294967296) - 2147483648
+           count4 = int(mod(int(iseed(np),8) + 2147483648_8, 4294967296_8) - 2147483648_8)
            print *,'using seed',count4,iseed(np)!,member_id
          endif
       endif

--- a/update_ca.F90
+++ b/update_ca.F90
@@ -305,7 +305,7 @@ integer, dimension(nxc,nyc) :: neighbours, birth, thresh
 integer, dimension(nxc,nyc) :: newcell, temp,newseed
 integer, dimension(ncells,ncells) :: onegrid
 integer(8)           :: nx_full,ny_full
-integer(8)           :: iscale = 10000000000
+integer(8)           :: iscale = 10000000000_8
 logical, save        :: start_from_restart
 
 real, dimension(nxc,nyc) :: noise_b
@@ -390,7 +390,7 @@ if(mod(kstep,nseed)==0. .and. (kstep >= initialize_ca .or. start_from_restart))t
             count_trunc = iscale*(count/iscale)
             count4 = count - count_trunc + mytile *( i1+nx_full*(j1-1)) ! no need to multply by 7 since time will be different in sgs
          else
-            count4 = mod((iseed_ca*nf+mytile)*(i1+nx_full*(j1-1))+ 2147483648, 4294967296) - 2147483648
+            count4 = int(mod(int((iseed_ca*nf+mytile)*(i1+nx_full*(j1-1)), 8) + 2147483648_8, 4294967296_8) - 2147483648_8)
          endif
          noise_b(i,j)=real(random_01_CB(kstep,count4),kind=8)
       enddo
@@ -597,7 +597,7 @@ real, dimension(nxc,nyc) :: noise_b
 integer(8) :: count, count_rate, count_max, count_trunc
 integer    :: count4
 integer(8) :: nx_full,ny_full
-integer(8) :: iscale = 10000000000
+integer(8) :: iscale = 10000000000_8
 integer*8            :: i1,j1
 
 !-------------------------------------------------------------------------------------------------
@@ -636,7 +636,7 @@ if(mod(kstep,nseed) == 0)then
             count_trunc = iscale*(count/iscale)
             count4 = count - count_trunc + mytile *( i1+nx_full*(j1-1)) ! no need to multply by 7 since time will be different in sgs
          else
-            count4 = mod(iseed_ca*nf+(7*mytile)*(i1+nx_full*(j1-1))+ 2147483648, 4294967296) - 2147483648
+            count4 = int(mod(int(iseed_ca*nf+(7*mytile)*(i1+nx_full*(j1-1)), 8) + 2147483648_8, 4294967296_8) - 2147483648_8)
          endif
          noise_b(i,j)=real(random_01_CB(kstep,count4),kind=8)
       enddo


### PR DESCRIPTION
The gnu compiler complained about mixing and matching 4- and 8-byte integers when compiling with CESM's DEBUG configuration (omitting -fno-range-check), these changes are bit-for-bit with intel compiler and DEBUG=FALSE but lets the model build / run with gnu as well.